### PR TITLE
Video Fixes 

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -2271,10 +2271,10 @@ class FunkinLua {
 			}
 			return false;
 		});
-		Lua_helper.add_callback(lua, "startVideo", function(videoFile:String) {
+		Lua_helper.add_callback(lua, "startVideo", function(videoFile:String, startEndSong:Bool = false) {
 			#if VIDEOS_ALLOWED
 			if(FileSystem.exists(Paths.video(videoFile))) {
-				PlayState.instance.startVideo(videoFile);
+				PlayState.instance.startVideo(videoFile, startEndSong);
 				return true;
 			} else {
 				LuaUtils.luaTrace(lua, 'startVideo: Video file not found: ' + videoFile, false, false, FlxColor.RED);
@@ -2282,10 +2282,12 @@ class FunkinLua {
 			return false;
 
 			#else
-			if(PlayState.instance.endingSong) {
-				PlayState.instance.endSong();
-			} else {
-				PlayState.instance.startCountdown();
+			if(startEndSong){
+				if(PlayState.instance.endingSong) {
+					PlayState.instance.endSong();
+				} else {
+					PlayState.instance.startCountdown();
+				}
 			}
 			return true;
 			#end

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1564,7 +1564,7 @@ class PlayState extends MusicBeatState
 		char.y += char.positionArray[1];
 	}
 
-	public function startVideo(name:String)
+	public function startVideo(name:String, ?startEnd:Bool = false)
 	{
 		#if VIDEOS_ALLOWED
 		inCutscene = true;
@@ -1577,7 +1577,8 @@ class PlayState extends MusicBeatState
 		#end
 		{
 			FlxG.log.warn('Couldnt find video file: ' + name);
-			startAndEnd();
+			callOnLuas('onVideoEnd', [name]);
+			if(startEnd) startAndEnd();
 			return;
 		}
 
@@ -1585,12 +1586,14 @@ class PlayState extends MusicBeatState
 		video.play(filepath);
 		video.onEndReached.add(function()
 		{
-			startAndEnd();
+			callOnLuas('onVideoEnd', [name]);
+			if(startEnd) startAndEnd();
 			return;
 		}, true);
 		#else
 		FlxG.log.warn('Platform not supported!');
-		startAndEnd();
+		callOnLuas('onVideoEnd', [name]);
+		if(startEnd) startAndEnd(); //Apparently startAndEnd() breaks mods with dialogue so it is able to be turned off by default now
 		return;
 		#end
 	}


### PR DESCRIPTION
Videos no longer break dialogue.

Added new lua callback `onVideoEnd(name:String)` which uses the filename of the video as the first parameter